### PR TITLE
chore: use create instead of apply

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -32,7 +32,7 @@ echo "CFG_FILE_PATH is $CFG_FILE_PATH"
 echo "install chaos mesh"
 helm version
 kubectl version
-kubectl apply -f ./manifests/crd.yaml
+kubectl create -f ./manifests/crd.yaml
 kubectl create ns chaos-testing
 helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
 


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

as the size of workflownode is too large, `kubectl apply` will failed to apply the object with failed message:
```
The CustomResourceDefinition "workflownodes.chaos-mesh.​org" is invalid: metadata.annotations: Too long: must have at most 262144 bytes.
```

we should use `kubectl create` instead. 