### PR TITLE
use kubectl create instead of apply to avoid crd TOO LONG

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -32,7 +32,7 @@ echo "CFG_FILE_PATH is $CFG_FILE_PATH"
 echo "install chaos mesh"
 helm version
 kubectl version
-kubectl apply -f ./manifests/crd.yaml
+kubectl create -f ./manifests/crd.yaml
 kubectl create ns chaos-testing
 helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
 


### PR DESCRIPTION
use chaos-mesh/chaos-mesh-action@master will report 
```
Error from server (Invalid): error when creating "./manifests/crd.yaml": CustomResourceDefinition.apiextensions.k8s.io "workflows.chaos-mesh.org" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```
Use kubectl create instead of kubectl apply